### PR TITLE
Fixes escapeQuotes util function for non-string values

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,11 @@ var child_process = require('child_process')
   , shellwords = require('shellwords');
 
 var escapeQuotes = function (str) {
-  return str.replace(/\"/g, '\\"');
+  if (typeof str === 'string') {
+    return str.replace(/\"/g, '\\"');
+  } else {
+    return str;
+  }
 };
 
 module.exports.command = function (notifier, options, cb) {


### PR DESCRIPTION
This fixes an issue with [gulp-notify](https://www.npmjs.org/package/gulp-notify).

gulp-notify has an onLast option that is a boolean. All options are passed through to node-notifier which attempts to sanitize all values as strings. Throws an exception due to .replace method not being defined on a boolean.
