### PR TITLE
Use local terminal-notifier executable when available

### DIFF
--- a/lib/notifiers/terminal-notifier.js
+++ b/lib/notifiers/terminal-notifier.js
@@ -6,7 +6,6 @@
  */
 
 var path = require('path')
-  , notifier = path.resolve(__dirname, '../../vendor/terminal-notifier.app/Contents/MacOS/terminal-notifier')
   , utils = require('../utils');
 
 var Notifier = function () {
@@ -21,22 +20,37 @@ var Notifier = function () {
   };
 };
 
+Notifier.prototype.useNotifier = function (callback) {
+  var notifier = 'terminal-notifier';
+
+  return utils.commandPresent(notifier, function (present) {
+    if (!present) {
+      notifier = path.resolve(__dirname, '../../vendor/terminal-notifier.app/Contents/MacOS/terminal-notifier');
+    }
+
+    return callback(notifier);
+  });
+};
+
 Notifier.prototype.notify = function (options, callback) {
     var argsList = utils.constructArgumentList(options);
     callback = cbAnnotator(callback || function (err, data) {});
 
-    if(this.isOSX) {
-      utils.command(notifier, argsList, callback);
-      return this;
-    }
-
     var self = this;
-    utils.isMacOSX(function (error, errorMsg) {
-      if (error) {
-        return callback(new Error(errorMsg));
+    this.useNotifier( function (notifier) {
+      if(self.isOSX) {
+        utils.command(notifier, argsList, callback);
+        return self;
       }
-      utils.command(notifier, argsList, callback);
-      self.isOSX = true;
+
+
+      utils.isMacOSX(function (error, errorMsg) {
+        if (error) {
+          return callback(new Error(errorMsg));
+        }
+        utils.command(notifier, argsList, callback);
+        self.isOSX = true;
+      });
     });
     return this;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,6 +32,16 @@ var inArray = function (arr, val) {
   return false;
 };
 
+module.exports.commandPresent = function (command, callback) {
+  return exec('which ' + command, function (error) {
+    if (error) {
+      return callback(false);
+    }
+
+    callback(true);
+  });
+};
+
 module.exports.constructArgumentList = function (options, initial, keyExtra, allowedArguments) {
   var args = [];
   keyExtra = keyExtra || "";

--- a/test/terminal-notifier.js
+++ b/test/terminal-notifier.js
@@ -17,6 +17,12 @@ var notifier = new NotificationCenter();
     describe('#notify()', function(){
 
       before(function (done) {
+        utils.commandPresent = function (command, callback) {
+          if (command == 'terminal-notifier') {
+            return callback(false);
+          }
+        };
+
         notifier.notify({
           remove: "ALL"
         }, function () { done(); });
@@ -70,6 +76,49 @@ var notifier = new NotificationCenter();
             done();
           });
         });
+      });
+    });
+
+    describe("terminal-notifier executable selection", function() {
+      before(function () {
+        this.original = utils.command;
+      });
+
+      after(function () {
+        utils.command = this.original;
+      });
+
+      it('should use the local terminal-notifier executable if available', function (done) {
+        utils.commandPresent = function (command, callback) {
+          if (command == 'terminal-notifier') {
+            return callback(true);
+          }
+        };
+
+        utils.command = function (notifier, argsList, callback) {
+          notifier.should.eql('terminal-notifier');
+          done();
+        };
+
+        var notifier = new NotificationCenter();
+        notifier.notify({message: "body"});
+      });
+
+      it('should use the vendored executable if a local executable is not available', function (done) {
+        utils.commandPresent = function (command, callback) {
+          if (command == 'terminal-notifier') {
+            return callback(false);
+          }
+        };
+
+        utils.command = function (notifier, argsList, callback) {
+          var using_vendored_executable = (notifier.indexOf('vendor/terminal-notifier.app/Contents/MacOS/terminal-notifier') != -1);
+          using_vendored_executable.should.eql(true);
+          done();
+        };
+
+        var notifier = new NotificationCenter();
+        notifier.notify({message: "body"});
       });
     });
 


### PR DESCRIPTION
The terminal-notifier executable included in the vendor directory is not
easily upgradeable, and certain users may wish to have more control over
which version of terminal-notifier is used (for instance to take
advantage of new -appIcon and -contentImage features). If a user needs
more control over terminal-notifier, this commit allows them to use
whatever version they have chosen to install locally via RubyGems or
Homebrew.
