### PR TITLE
Fixed expire-time flag in notify-send.

### DIFF
--- a/lib/notifiers/notify-send.js
+++ b/lib/notifiers/notify-send.js
@@ -19,17 +19,37 @@ var Notifier = function () {
 
 var allowedArguments = [
   "urgency",
-  "expire",
+  "expire-time",
   "icon",
   "category",
   "hint"
 ];
+
+var notifySendFlags = {
+  "u":            "urgency",
+  "urgency":      "urgency",
+  "e":            "expire-time",
+  "expire":       "expire-time",
+  "expire-time":  "expire-time",
+  "i":            "icon",
+  "icon":         "icon",
+  "c":            "category",
+  "category":     "category",
+  "h":            "hint",
+  "hint":         "hint"
+}
 
 var doNotification = function (options, callback) {
   options.title = options.title || 'Node Notification:';
   var initial = [options.title, options.message];
   delete options.title;
   delete options.message;
+  for (var key in options) {
+    if (options.hasOwnProperty(key) && (notifySendFlags[key] != key)) {
+      options[notifySendFlags[key]] = options[key];
+      delete options[key];
+    }
+  }
   var argsList = utils.constructArgumentList(options, initial, "-", allowedArguments);
 
   utils.command(notifier, argsList, callback);


### PR DESCRIPTION
In order to resolve #13, I changed `lib/notifiers/notify-send.js` to allow for either `expire-time` or `expire`, and added a first-letter-only option (e.g. `e` maps to `expire-time`, `u` maps to `urgency`, etc) for each possible notify-send argument for more concise naming if desired.
