### PR TITLE
Added one more end state (error code) for balloon notifier.

### DIFF
--- a/notifiers/balloon.js
+++ b/notifiers/balloon.js
@@ -123,14 +123,16 @@ function doNotification (options, notifierOptions, callback) {
 }
 
 function fromErrorCodeToAction (errorCode) {
-  if (errorCode === 2) {
-    return 'timeout';
+  switch (errorCode) {
+    case 2:
+      return 'timeout';
+    case 3:
+    case 6:
+    case 7:
+      return 'activate';
+    case 4:
+      return 'close';
+    default:
+      return 'error';
   }
-  if (errorCode === 3 || errorCode === 6 || errorCode === 7) {
-    return 'activate';
-  }
-  if (errorCode === 4) {
-    return 'close';
-  }
-  return 'error';
 }

--- a/notifiers/balloon.js
+++ b/notifiers/balloon.js
@@ -126,7 +126,7 @@ function fromErrorCodeToAction (errorCode) {
   if (errorCode === 2) {
     return 'timeout';
   }
-  if (errorCode === 3) {
+  if (errorCode === 3 || errorCode === 6 || errorCode === 7) {
     return 'activate';
   }
   if (errorCode === 4) {

--- a/notifiers/balloon.js
+++ b/notifiers/balloon.js
@@ -19,6 +19,7 @@ Usage
 // Kill codes:
   2 = Timeout
   3 = Clicked
+  4 = Closed or faded out
 
  */
 var path = require('path'),
@@ -127,6 +128,9 @@ function fromErrorCodeToAction (errorCode) {
   }
   if (errorCode === 3) {
     return 'activate';
+  }
+  if (errorCode === 4) {
+    return 'close';
   }
   return 'error';
 }


### PR DESCRIPTION
If Notifu ends with error code `4` it means, that the balloon has been closed with the `x` mark or it faded out, after moving mouse/pressing a key.