### PR TITLE
Allow terminal-notifier syntax to work with notify-send

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,6 +35,7 @@ var notifySendFlags = {
   "icon":         "icon",
   "c":            "category",
   "category":     "category",
+  "subtitle":     "category",
   "h":            "hint",
   "hint":         "hint"
 };


### PR DESCRIPTION
This will allow a sort of unified syntax.