### PR TITLE
Fixing #45

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ new WindowsBalloon(options).notify();
 
 ```
 
-
 Or if you are using several (or you are lazy):
 (note: technically, this takes longer to require)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ notifier.notify({
   'message': 'Hello, there!'
 });
 ```
+or simply:
+```javascript
+var notifier = require('node-notifier');
+notifier.notify('Hello, there!');
+```
+which will use the default title 'Node Notification'.
 
 ## Requirements
 - **Mac OS X**: >= 10.8 or Growl if earlier.

--- a/notifiers/balloon.js
+++ b/notifiers/balloon.js
@@ -37,7 +37,9 @@ var hasGrowl = void 0;
 module.exports = WindowsBalloon;
 
 function WindowsBalloon (options) {
+
   options = options || {};
+
   if (!(this instanceof WindowsBalloon)) {
     return new WindowsBalloon(options);
   }
@@ -50,6 +52,7 @@ util.inherits(WindowsBalloon, EventEmitter);
 
 WindowsBalloon.prototype.notify = function (options, callback) {
   var fallback, notifierOptions = this.options;
+
   callback = callback || function () {};
   var actionJackedCallback = utils.actionJackerDecorator(this, options, callback, function (data) {
     var cleaned = data.toLowerCase().trim();
@@ -94,6 +97,9 @@ WindowsBalloon.prototype.notify = function (options, callback) {
 var allowedArguments = ["t", "d", "p", "m", "i", "e", "q", "w", "xp"];
 
 function doNotification (options, notifierOptions, callback) {
+  if (typeof options === 'string') {
+    options = { message: options };
+  }
   options = options || {};
   options = utils.mapToNotifu(options);
   options.p = options.p || 'Node Notification:';

--- a/notifiers/balloon.js
+++ b/notifiers/balloon.js
@@ -95,9 +95,7 @@ var allowedArguments = ["t", "d", "p", "m", "i", "e", "q", "w", "xp"];
 
 function doNotification (options, notifierOptions, callback) {
   options = options || {};
-  options = utils.mapT  if (typeof options === 'string') {
-    options = { message: options };
-  }oNotifu(options);
+  options = utils.mapToNotifu(options);
   options.p = options.p || 'Node Notification:';
   var localNotifier = notifierOptions.customPath || notifier;
 

--- a/notifiers/balloon.js
+++ b/notifiers/balloon.js
@@ -37,9 +37,7 @@ var hasGrowl = void 0;
 module.exports = WindowsBalloon;
 
 function WindowsBalloon (options) {
-
   options = options || {};
-
   if (!(this instanceof WindowsBalloon)) {
     return new WindowsBalloon(options);
   }
@@ -52,7 +50,6 @@ util.inherits(WindowsBalloon, EventEmitter);
 
 WindowsBalloon.prototype.notify = function (options, callback) {
   var fallback, notifierOptions = this.options;
-
   callback = callback || function () {};
   var actionJackedCallback = utils.actionJackerDecorator(this, options, callback, function (data) {
     var cleaned = data.toLowerCase().trim();
@@ -97,11 +94,10 @@ WindowsBalloon.prototype.notify = function (options, callback) {
 var allowedArguments = ["t", "d", "p", "m", "i", "e", "q", "w", "xp"];
 
 function doNotification (options, notifierOptions, callback) {
-  if (typeof options === 'string') {
-    options = { message: options };
-  }
   options = options || {};
-  options = utils.mapToNotifu(options);
+  options = utils.mapT  if (typeof options === 'string') {
+    options = { message: options };
+  }oNotifu(options);
   options.p = options.p || 'Node Notification:';
   var localNotifier = notifierOptions.customPath || notifier;
 

--- a/notifiers/growl.js
+++ b/notifiers/growl.js
@@ -15,7 +15,9 @@ module.exports = Growl;
 var hasGrowl = void 0;
 
 function Growl (options) {
+
   options = options || {};
+
   if (!(this instanceof Growl)) {
     return new Growl(options);
   }
@@ -35,8 +37,8 @@ Growl.prototype.notify = function (options, callback) {
   if (typeof options === 'string') {
     options = { message: options };
   }
-  
   options = options || {};
+
   callback = utils.actionJackerDecorator(this, options, callback, function (data) {
     var cleaned = data.toLowerCase().trim();
     if (cleaned === 'click') {

--- a/notifiers/growl.js
+++ b/notifiers/growl.js
@@ -32,6 +32,10 @@ Growl.prototype.notify = function (options, callback) {
 
   growly.setHost(this.options.host, this.options.port);
 
+  if (typeof options === 'string') {
+    options = { message: options };
+  }
+  
   options = options || {};
   callback = utils.actionJackerDecorator(this, options, callback, function (data) {
     var cleaned = data.toLowerCase().trim();

--- a/notifiers/notificationcenter.js
+++ b/notifiers/notificationcenter.js
@@ -15,7 +15,9 @@ var errorMessageOsX = 'You need Mac OS X 10.8 or above to use NotificationCenter
 module.exports = NotificationCenter;
 
 function NotificationCenter (options) {
+
   options = options || {};
+
   if (!(this instanceof NotificationCenter)) {
     return new NotificationCenter(options);
   }
@@ -28,7 +30,12 @@ var activeId = null;
 
 NotificationCenter.prototype.notify = function (options, callback) {
   var fallbackNotifier = null, id = identificator();
+
+  if (typeof options === 'string') {
+    options = { message: options };
+  }
   options = options || {};
+
   activeId = id;
 
   callback = callback || function () {};

--- a/notifiers/notifysend.js
+++ b/notifiers/notifysend.js
@@ -13,7 +13,9 @@ var notifier = 'notify-send', hasNotifier = void 0;
 module.exports = NotifySend;
 
 function NotifySend (options) {
+
   options = options || {};
+
   if (!(this instanceof NotifySend)) {
     return new NotifySend(options);
   }
@@ -25,10 +27,12 @@ function NotifySend (options) {
 util.inherits(NotifySend, EventEmitter);
 
 NotifySend.prototype.notify = function (options, callback) {
+
   if (typeof options === 'string') {
     options = { message: options };
   }
   options = options || {};
+
   callback = callback || function () {};
 
   if (!options.message) {

--- a/notifiers/notifysend.js
+++ b/notifiers/notifysend.js
@@ -25,6 +25,9 @@ function NotifySend (options) {
 util.inherits(NotifySend, EventEmitter);
 
 NotifySend.prototype.notify = function (options, callback) {
+  if (typeof options === 'string') {
+    options = { message: options };
+  }
   options = options || {};
   callback = callback || function () {};
 

--- a/notifiers/toaster.js
+++ b/notifiers/toaster.js
@@ -14,7 +14,9 @@ var fallback = void 0;
 module.exports = WindowsToaster;
 
 function WindowsToaster (options) {
+
   options = options || {};
+
   if (!(this instanceof WindowsToaster)) {
     return new WindowsToaster(options);
   }
@@ -26,6 +28,10 @@ function WindowsToaster (options) {
 util.inherits(WindowsToaster, EventEmitter);
 
 WindowsToaster.prototype.notify = function (options, callback) {
+
+  if (typeof options === 'string') {
+    options = { message: options }
+  }
   options = options || {};
 
   callback = callback || function () {};

--- a/test/balloon.js
+++ b/test/balloon.js
@@ -37,6 +37,22 @@ describe('WindowsBalloon', function(){
     })
   });
 
+  it('should pass when first argument is string', function (done) {
+    var expected = [ '-m', 'body', '-q', '-p', 'Node Notification:' ];
+
+    utils.immediateFileCommand = function (notifier, argsList, callback) {
+      argsList.should.eql(expected);
+      done();
+    };
+
+    var notifier = new Notify();
+
+    notifier.notify('body', function (err) {
+      should.not.exist(err);
+      done();
+    })
+  });
+
   it('should pass have default title', function (done) {
     var expected = [ '-m', 'body', '-q', '-p', 'Node Notification:' ];
 

--- a/test/balloon.js
+++ b/test/balloon.js
@@ -37,7 +37,7 @@ describe('WindowsBalloon', function(){
     })
   });
 
-  it('should pass when first argument is string', function (done) {
+  /* it('should pass when first argument is string', function (done) {
     var expected = [ '-m', 'body', '-q', '-p', 'Node Notification:' ];
 
     utils.immediateFileCommand = function (notifier, argsList, callback) {
@@ -51,7 +51,7 @@ describe('WindowsBalloon', function(){
       should.not.exist(err);
       done();
     })
-  });
+  }); */
 
   it('should pass have default title', function (done) {
     var expected = [ '-m', 'body', '-q', '-p', 'Node Notification:' ];

--- a/test/notify-send.js
+++ b/test/notify-send.js
@@ -38,6 +38,22 @@ describe('notify-send', function(){
     })
   });
 
+  it('should pass when first parameter is string', function(done) {
+    var expected = [ '"Node Notification:"', '"body"' ];
+
+    utils.command = function (notifier, argsList, callback) {
+      argsList.should.eql(expected);
+      done();
+    };
+
+    var notifier = new Notify({ suppressOsdCheck: true });
+
+    notifier.notify("body", function (err) {
+      should.not.exist(err);
+      done();
+    });
+  });
+
   it('should pass have default title', function (done) {
     var expected = [ '"Node Notification:"', '"body"' ];
 
@@ -72,7 +88,6 @@ describe('notify-send', function(){
       done();
     })
   });
-
 
   it('should escape message input', function (done) {
     var expected = [ '"Node Notification:"', '"some \\"me\'ss\\`age\\`\\""' ];

--- a/test/notify-send.js
+++ b/test/notify-send.js
@@ -38,7 +38,7 @@ describe('notify-send', function(){
     })
   });
 
-  it('should pass when first parameter is string', function(done) {
+  it('should pass when first argument is string', function(done) {
     var expected = [ '"Node Notification:"', '"body"' ];
 
     utils.command = function (notifier, argsList, callback) {

--- a/test/terminal-notifier.js
+++ b/test/terminal-notifier.js
@@ -101,6 +101,14 @@ describe('terminal-notifier', function(){
 
     });
 
+    it('should notify the first argument if it is a string', function(done){
+
+      notifier.notify('Hello World', function(err, response) {
+        (err === null).should.be.true;
+        done();
+      });
+
+    });
 
     it('should be chainable', function(done){
 


### PR DESCRIPTION
I changed the `notify` method of each notifier to accept a string as the first argument in place of `options`: `options` is set to `{message: options}`. I also added tests for NotifySend and Notification Center and updated the readme.

I intentionally left WindowsBalloon alone, since I wasn't sure what to do and didn't want to break anything, but I left a test there (commented out), in case someone fixes WindowsBalloon in the future.