### PR TITLE
Use 'which' in 'notifiy-send' notifier synchronously. Prevents strange options deletion

### DIFF
--- a/notifiers/notifysend.js
+++ b/notifiers/notifysend.js
@@ -48,15 +48,14 @@ NotifySend.prototype.notify = function (options, callback) {
     return this;
   }
 
-  which(notifier, function (err) {
-    hasNotifier = !err;
-
-    if (err) {
-      return callback(err);
-    }
-
+  try {
+    hasNotifier = !!which.sync(notifier);
     doNotification(options, callback);
-  });
+  } catch (err) {
+    hasNotifier = false;
+    return callback(err);
+  };
+  
   return this;
 };
 


### PR DESCRIPTION
I ran into strange behaviors when using the gulp plugin 'gulp-notify' with JSHint (or basically from a stream of several inputs) on my Ubuntu machine.

Only the last error message was showing up, all the other notifications was the defaults one ('Node Notification' // 'undefined').

By using 'which' plugin that checks if 'notify-send' exists in a synchronous way, it solved the issue. I'm not really sure why though...