### PR TITLE
CLI: do not show an empty message

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -21,6 +21,10 @@ var argv = minimist(process.argv.slice(2), {
 readme(aliases);
 
 var options = getOptionsIfExists(Object.keys(aliases), argv);
+if (!options.message) {
+  // Do not show an empty message
+  process.exit(0);
+}
 notifier.notify(options, function (err, msg) {
   if (err) {
     console.error(err.message);


### PR DESCRIPTION
Redirecting stdout of a tool to the notification is a really
useful workflow to receive errors: `my-tool | xargs -0 notify -m`
However, because `xargs -r` is not cross-platform,
the result is a constant stream of empty notifications.