### PR TITLE
Bin: set string options

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -15,7 +15,8 @@ var aliases = {
 };
 
 var argv = minimist(process.argv.slice(2), {
-  alias: aliases
+  alias: aliases,
+  string: ['icon', 'message', 'open', 'subtitle', 'title']
 });
 
 readme(aliases);


### PR DESCRIPTION
Without this, titles and messages become `true` if given on a command line with no argument.