### PR TITLE
Add support for remote growl server

### DIFF
--- a/lib/checkGrowl.js
+++ b/lib/checkGrowl.js
@@ -5,13 +5,12 @@ var hasGrowl = false;
 module.exports = function (growlConfig, cb) {
   if (typeof cb == 'undefined') {
     cb = growlConfig;
-    growlConfig = {
-      port: 23053,
-      host: 'localhost'
-    };
+    growlConfig = {};
   }
   if (hasGrowl) return cb(hasGrowl);
-  var socket = net.connect(growlConfig.port, growlConfig.host);
+  port = growlConfig.port || 23053;
+  host = growlConfig.host || 'localhost';
+  var socket = net.connect(port, host);
   socket.setTimeout(100);
 
   socket.on('connect', function() {

--- a/lib/checkGrowl.js
+++ b/lib/checkGrowl.js
@@ -1,11 +1,17 @@
 var net = require('net');
 
 var hasGrowl = false;
-var port = 23053;
 
-module.exports = function (cb) {
+module.exports = function (growlConfig, cb) {
+  if (typeof cb == 'undefined') {
+    cb = growlConfig;
+    growlConfig = {
+      port: 23053,
+      host: 'localhost'
+    };
+  }
   if (hasGrowl) return cb(hasGrowl);
-  var socket = net.connect(port);
+  var socket = net.connect(growlConfig.port, growlConfig.host);
   socket.setTimeout(100);
 
   socket.on('connect', function() {

--- a/lib/checkGrowl.js
+++ b/lib/checkGrowl.js
@@ -8,8 +8,8 @@ module.exports = function (growlConfig, cb) {
     growlConfig = {};
   }
   if (hasGrowl) return cb(hasGrowl);
-  port = growlConfig.port || 23053;
-  host = growlConfig.host || 'localhost';
+  var port = growlConfig.port || 23053;
+  var host = growlConfig.host || 'localhost';
   var socket = net.connect(port, host);
   socket.setTimeout(100);
 

--- a/notifiers/balloon.js
+++ b/notifiers/balloon.js
@@ -79,7 +79,7 @@ WindowsBalloon.prototype.notify = function (options, callback) {
     return this;
   }
 
-  checkGrowl(function (hasGrowlResult) {
+  checkGrowl(notifierOptions, function (hasGrowlResult) {
     hasGrowl = hasGrowlResult;
 
     if (hasGrowl) {

--- a/notifiers/growl.js
+++ b/notifiers/growl.js
@@ -60,7 +60,7 @@ Growl.prototype.notify = function (options, callback) {
     return this;
   }
 
-  checkGrowl(function (didHaveGrowl) {
+  checkGrowl(growly, function (didHaveGrowl) {
     hasGrowl = didHaveGrowl;
     if (!didHaveGrowl) return callback(new Error(errorMessageNotFound));
     growly.notify(options.message, options);


### PR DESCRIPTION
`checkGrowl` will fail if trying to run against a remote growl server by setting growl host.

Using the example from the docs:

```js
var Growl = require('node-notifier').Growl;

var GROWL_HOST = '10.0.2.2';

var notifier = new Growl({
  name: 'Growl Name Used', // Defaults as 'Node'
  host: GROWL_HOST,
  port: 23053
});

notifier.notify({
  title: 'Foo',
  message: 'Hello World',
  wait: false, // if wait for user interaction

  // and other growl options like sticky etc.
  sticky: false,
  label: void 0,
  priority: void 0
}, function (err, res) {
  console.log(err, res);
});
```

This gives an error that growl can't be connected to. `checkGrowl` is trying to connect to 'localhost', which fails.