### PR TITLE
Sanitize response on `notify` callback

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -162,14 +162,19 @@ module.exports.actionJackerDecorator = function (emitter, options, fn, mapper) {
   options = clone(options);
   fn = fn || function (err, data) {};
   return function (err, data) {
-    var cleanedData = data.toLowerCase().trim();
-    if(cleanedData.match(/^activate/)) {
-      cleanedData = 'activate';
-    }
-    fn.apply(emitter, [err, cleanedData]);
-    if (err || !mapper || !cleanedData) return;
 
-    var key = mapper(cleanedData);
+    var resultantData = data;
+    // Sanitize the data
+    if(resultantData) {
+      resultantData = resultantData.toLowerCase().trim();
+      if(resultantData.match(/^activate/)) {
+        resultantData = 'activate';
+      }
+    }
+    fn.apply(emitter, [err, resultantData]);
+    if (err || !mapper || !resultantData) return;
+
+    var key = mapper(resultantData);
     if (!key) return;
     emitter.emit(key, emitter, options);
   };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -162,10 +162,14 @@ module.exports.actionJackerDecorator = function (emitter, options, fn, mapper) {
   options = clone(options);
   fn = fn || function (err, data) {};
   return function (err, data) {
-    fn.apply(emitter, [err, data]);
-    if (err || !mapper || !data) return;
+    var cleanedData = data.toLowerCase().trim();
+    if(cleanedData.match(/^activate/)) {
+      cleanedData = 'activate';
+    }
+    fn.apply(emitter, [err, cleanedData]);
+    if (err || !mapper || !cleanedData) return;
 
-    var key = mapper(data);
+    var key = mapper(cleanedData);
     if (!key) return;
     emitter.emit(key, emitter, options);
   };

--- a/notifiers/balloon.js
+++ b/notifiers/balloon.js
@@ -59,13 +59,12 @@ WindowsBalloon.prototype.notify = function (options, callback) {
       title: 'node-notifier',
       message: options
   };
-  
+
   var actionJackedCallback = utils.actionJackerDecorator(this, options, callback, function (data) {
-    var cleaned = data.toLowerCase().trim();
-    if (cleaned === 'activate') {
+    if (data === 'activate') {
       return 'click';
     }
-    if (cleaned === 'timeout') {
+    if (data === 'timeout') {
       return 'timeout';
     }
     return false;

--- a/notifiers/growl.js
+++ b/notifiers/growl.js
@@ -39,11 +39,10 @@ Growl.prototype.notify = function (options, callback) {
   };
 
   callback = utils.actionJackerDecorator(this, options, callback, function (data) {
-    var cleaned = data.toLowerCase().trim();
-    if (cleaned === 'click') {
+    if (data === 'click') {
       return 'click';
     }
-    if (cleaned === 'timedout') {
+    if (data === 'timedout') {
       return 'timeout';
     }
     return false;

--- a/notifiers/notificationcenter.js
+++ b/notifiers/notificationcenter.js
@@ -41,11 +41,10 @@ NotificationCenter.prototype.notify = function (options, callback) {
   var actionJackedCallback = utils.actionJackerDecorator(this, options, callback, function (data) {
     if (activeId !== id) return false;
 
-    var cleaned = data.toLowerCase().trim();
-    if (cleaned === 'activate') {
+    if (data === 'activate') {
       return 'click';
     }
-    if (cleaned === 'timeout') {
+    if (data === 'timeout') {
       return 'timeout';
     }
     return false;

--- a/notifiers/toaster.js
+++ b/notifiers/toaster.js
@@ -34,13 +34,12 @@ WindowsToaster.prototype.notify = function (options, callback) {
       title: 'node-notifier',
       message: options
   };
-  
+
   var actionJackedCallback = utils.actionJackerDecorator(this, options, callback, function (data) {
-    var cleaned = data.toLowerCase().trim();
-    if (cleaned === 'activated') {
+    if (data === 'activate') {
       return 'click';
     }
-    if (cleaned === 'timeout') {
+    if (data === 'timeout') {
       return 'timeout';
     }
     return false;


### PR DESCRIPTION
Sanitize response on `notify` callback
 - Lowercase all response data
 - Trim whitespace
 - Return `activate` instead of `Activate` or `Activated`

Covers https://github.com/mikaelbr/node-notifier/issues/101

This is a breaking change.

Here is another upstream change from `toaster` that isn't necessary but will make life easier for consuming the API safely if someone forgets to sanitize: https://github.com/mikaelbr/toaster/pull/2