### PR TITLE
Add support for passing type option to WindowsBalloon (notifu)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -313,6 +313,11 @@ module.exports.mapToNotifu = function (options) {
     delete options.t;
   }
 
+  if (options.type) {
+    options.t = sanitizeNotifuTypeArgument(options.type);
+    delete options.type;
+  }
+
   return options;
 };
 
@@ -337,4 +342,17 @@ function garanteeSemverFormat (version) {
     version += '.0';
   }
   return version;
+}
+
+function sanitizeNotifuTypeArgument(type) {
+  if (typeof type === 'string' || type instanceof String) {
+    if (type.toLowerCase() == 'info')
+      return 'info';
+    if (type.toLowerCase() == 'warn')
+      return 'warn';
+    if (type.toLowerCase() == 'error')
+      return 'error';
+  }
+
+  return 'info';
 }

--- a/test/balloon.js
+++ b/test/balloon.js
@@ -248,4 +248,80 @@ describe('WindowsBalloon', function(){
     })
   });
 
+  it('should have both type and duration options', function (done) {
+    var expected = [ '-m', 'body', '-p', 'title', '-q', '-d', '10', '-t', 'info' ];
+
+    utils.immediateFileCommand = function (notifier, argsList, callback) {
+      argsList.should.eql(expected);
+      done();
+    };
+
+    var notifier = new Notify();
+
+    notifier.notify({
+      title: "title",
+      message: "body",
+      type: "info",
+      t: 10
+    }, function (err) {
+      should.not.exist(err);
+    })
+  });
+
+  it('should sanitize wrong string type option to info', function (done) {
+    var expected = [ '-m', 'body', '-p', 'title', '-q', '-t', 'info' ];
+
+    utils.immediateFileCommand = function (notifier, argsList, callback) {
+      argsList.should.eql(expected);
+      done();
+    };
+
+    var notifier = new Notify();
+
+    notifier.notify({
+      title: "title",
+      message: "body",
+      type: "theansweris42"
+    }, function (err) {
+      should.not.exist(err);
+    })
+  });
+
+  it('should sanitize type option to error', function (done) {
+    var expected = [ '-m', 'body', '-p', 'title', '-q', '-t', 'error' ];
+
+    utils.immediateFileCommand = function (notifier, argsList, callback) {
+      argsList.should.eql(expected);
+      done();
+    };
+
+    var notifier = new Notify();
+
+    notifier.notify({
+      title: "title",
+      message: "body",
+      type: "ErRoR"
+    }, function (err) {
+      should.not.exist(err);
+    })
+  });
+
+  it('should sanitize wring integer type option to info', function (done) {
+    var expected = [ '-m', 'body', '-p', 'title', '-q', '-t', 'info' ];
+
+    utils.immediateFileCommand = function (notifier, argsList, callback) {
+      argsList.should.eql(expected);
+      done();
+    };
+
+    var notifier = new Notify();
+
+    notifier.notify({
+      title: "title",
+      message: "body",
+      type: 42
+    }, function (err) {
+      should.not.exist(err);
+    })
+  });
 });


### PR DESCRIPTION
Add support for passing 'type' option when using 'WindowsBalloon' (throught notifu).
Also handle sanitation of the give option for fallback
Add tests to check functionality