### PR TITLE
Fixed a bug that did not work on windows8.1.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -360,11 +360,7 @@ module.exports.mapToWin8 = function(options) {
     options.appID = options.appName;
     delete options.appName;
   } else {
-    options.appID = ' ';
-  }
-
-  if (typeof options.appID === 'undefined') {
-    options.appID = ' ';
+    delete options.appID
   }
 
   if (typeof options.remove !== 'undefined') {


### PR DESCRIPTION
https://github.com/KDE/snoretoast#snoretoast

If your application already has a shortcut in the startmenu, which provides an appID please pass this appID, an appID is needed and is also used to determine the application icon displayed in the toast notification.

SnoreToast.exe -m "msg" -t "title" -appID " "     -->  fail
SnoreToast.exe -m "msg" -t "title" -appID ""      -->  success
SnoreToast.exe -m "msg" -t "title"                      -->  success  --> best!

:)