### PR TITLE
Fix notification on windows

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -364,7 +364,7 @@ module.exports.mapToWin8 = function(options) {
   }
 
   if (typeof options.appID === 'undefined') {
-    options.appID = ' ';
+    delete options.appID;
   }
 
   if (typeof options.remove !== 'undefined') {


### PR DESCRIPTION
On windows 8.1 and Windows 10, if appID is equal to an empty string, the notification won't show up.

Deleting appID fix the issue because `-appID` won't be passed as an argument to SnoreToast.