### PR TITLE
appID option not being set when passed to Snoar Toast (WIN10)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -359,11 +359,7 @@ module.exports.mapToWin8 = function(options) {
   if (options.appName) {
     options.appID = options.appName;
     delete options.appName;
-  } else {
-    options.appID = ' ';
-  }
-
-  if (typeof options.appID === 'undefined') {
+  } else if (typeof options.appID === 'undefined') {
     options.appID = ' ';
   }
 


### PR DESCRIPTION
A bug I encountered was that if I would pass `appID` option for windows toast, it would be removed and not set as an option for Snoar Toast.  
For it to work I had to use `appName` option then it worked perfectly fine.  
I could've created PR for [README](https://github.com/mikaelbr/node-notifier/blob/master/README.md#all-notification-options-with-their-defaults) to change the API description. 
However, code change will be more consistent for the API that `node-notifier` is using.