### PR TITLE
Use a more specific condition for debug output.

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -7,7 +7,7 @@ node-notifier love getting pull requests and other help. Here's a quick guide.
 If you want to see what command is run, execute the node program with environment variable `DEBUG=true`, e.g.:
 
 ```
-DEBUG=true node index.js
+DEBUG="notifier" node index.js
 ```
 
 ```

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ var notifySendFlags = {
 
 module.exports.command = function(notifier, options, cb) {
   notifier = shellwords.escape(notifier);
-  if (process.env.DEBUG) {
+  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') != -1) {
     console.info('node-notifier debug info (command):');
     console.info('[notifier path]', notifier);
     console.info('[notifier options]', options.join(' '));
@@ -58,7 +58,7 @@ module.exports.command = function(notifier, options, cb) {
 };
 
 module.exports.fileCommand = function(notifier, options, cb) {
-  if (process.env.DEBUG) {
+  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') != -1) {
     console.info('node-notifier debug info (fileCommand):');
     console.info('[notifier path]', notifier);
     console.info('[notifier options]', options.join(' '));
@@ -71,7 +71,7 @@ module.exports.fileCommand = function(notifier, options, cb) {
 };
 
 module.exports.fileCommandJson = function(notifier, options, cb) {
-  if (process.env.DEBUG) {
+  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') != -1) {
     console.info('node-notifier debug info (fileCommandJson):');
     console.info('[notifier path]', notifier);
     console.info('[notifier options]', options.join(' '));
@@ -90,7 +90,7 @@ module.exports.fileCommandJson = function(notifier, options, cb) {
 };
 
 module.exports.immediateFileCommand = function(notifier, options, cb) {
-  if (process.env.DEBUG) {
+  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') != -1) {
     console.info('node-notifier debug info (notifier):');
     console.info('[notifier path]', notifier);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,7 +42,7 @@ var notifySendFlags = {
 
 module.exports.command = function(notifier, options, cb) {
   notifier = shellwords.escape(notifier);
-  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') != -1) {
+  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') !== -1) {
     console.info('node-notifier debug info (command):');
     console.info('[notifier path]', notifier);
     console.info('[notifier options]', options.join(' '));
@@ -58,7 +58,7 @@ module.exports.command = function(notifier, options, cb) {
 };
 
 module.exports.fileCommand = function(notifier, options, cb) {
-  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') != -1) {
+  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') !== -1) {
     console.info('node-notifier debug info (fileCommand):');
     console.info('[notifier path]', notifier);
     console.info('[notifier options]', options.join(' '));
@@ -71,7 +71,7 @@ module.exports.fileCommand = function(notifier, options, cb) {
 };
 
 module.exports.fileCommandJson = function(notifier, options, cb) {
-  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') != -1) {
+  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') !== -1) {
     console.info('node-notifier debug info (fileCommandJson):');
     console.info('[notifier path]', notifier);
     console.info('[notifier options]', options.join(' '));
@@ -90,7 +90,7 @@ module.exports.fileCommandJson = function(notifier, options, cb) {
 };
 
 module.exports.immediateFileCommand = function(notifier, options, cb) {
-  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') != -1) {
+  if (process.env.DEBUG && process.env.DEBUG.indexOf('notifier') !== -1) {
     console.info('node-notifier debug info (notifier):');
     console.info('[notifier path]', notifier);
   }


### PR DESCRIPTION
When someone uses [visionmedia/debug](https://github.com/visionmedia/debug) for logging he has to set `process.env.DEBUG` for enabling his own log messages.
He always sees the following output, because `node-notifier` only checks for the presence of the env var (`if (process.env.DEBUG)`):

```
node-notifier debug info (fileCommandJson):
[notifier path] [...]/node_modules/node-notifier/vendor/terminal-notifier.app/Contents/MacOS/terminal-notifier
[notifier options] -title "xyz" -message "🎉 some message here" -json "true"
```

Instead of checking for the presence you could check for the package name inside of the env var. Then someone could enable debug logging for `node-notifier` with setting the env var to something like this:
````
process.env.DEBUG = 'some-other,notifier';
````