### PR TITLE
fix: link notifier time property to notify-send expire-time flag

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,6 +28,7 @@ var notifySendFlags = {
   u: 'urgency',
   urgency: 'urgency',
   t: 'expire-time',
+  time: 'expire-time',
   e: 'expire-time',
   expire: 'expire-time',
   'expire-time': 'expire-time',

--- a/test/notify-send.js
+++ b/test/notify-send.js
@@ -73,7 +73,7 @@ describe('notify-send', function() {
   it(
     'should remove extra options that are not supported by notify-send',
     function(done) {
-      var expected = [ '"title"', '"body"', '--icon', '"icon-string"' ];
+      var expected = [ '"title"', '"body"', '--icon', '"icon-string"', '--expire-time', '"100"' ];
 
       expectArgsListToBe(expected, done);
       var notifier = new Notify({ suppressOsdCheck: true });
@@ -81,6 +81,7 @@ describe('notify-send', function() {
         title: 'title',
         message: 'body',
         icon: 'icon-string',
+        time: 100,
         tullball: 'notValid'
       });
     }


### PR DESCRIPTION
The `time` property specified in the documentation had
no effect since it wasn't link to notify-send
expire-time flag
