### PR TITLE
Add feature to clear notifier processes

### DIFF
--- a/notifiers/notificationcenter.js
+++ b/notifiers/notificationcenter.js
@@ -21,11 +21,22 @@ function NotificationCenter(options) {
     return new NotificationCenter(options);
   }
   this.options = options;
+  this.notifications = [];
 
   EventEmitter.call(this);
 }
 util.inherits(NotificationCenter, EventEmitter);
 var activeId = null;
+
+/**
+ * Call this to cancel timeouts on current notifications
+ */
+NotificationCenter.prototype.clearAll = function() {
+  for (var i in this.notifications) {
+    this.notifications[i].kill();
+  }
+  this.notifications = [];
+};
 
 function noop() {}
 NotificationCenter.prototype.notify = function(options, callback) {
@@ -75,11 +86,19 @@ NotificationCenter.prototype.notify = function(options, callback) {
 
   var argsList = utils.constructArgumentList(options);
   if (utils.isMountainLion()) {
-    utils.fileCommandJson(
+    // This will be the index of the newly added notification once its been
+    // added
+    let index = this.notifications.length;
+    let p = utils.fileCommandJson(
       this.options.customPath || notifier,
       argsList,
-      actionJackedCallback
+      function(e, data) {
+        // delete the notification since its been cleared
+        this.notifications.splice(index, 1);
+        actionJackedCallback(e, data);
+      }.bind(this)
     );
+    this.notifications.push(p);
     return this;
   }
 

--- a/test/terminal-notifier.js
+++ b/test/terminal-notifier.js
@@ -308,4 +308,42 @@ describe('terminal-notifier', function() {
       });
     });
   });
+
+  describe('#clearAll()', function() {
+    let mockProcess = {
+      kill: jest.fn()
+    };
+    beforeEach(function() {
+      // reset mock for each test
+      mockProcess.kill = jest.fn();
+      utils.fileCommandJson = function() {
+        return mockProcess;
+      };
+    });
+
+    afterEach(function() {
+      utils.fileCommandJson = originalUtils;
+    });
+
+    it('should kill all terminal-notifier processes', function() {
+      notifier.notify({ message: 'Hello World' }, function() {});
+      notifier.clearAll();
+      expect(mockProcess.kill.mock.calls.length).toBe(1);
+    });
+
+    it('should not kill finished terminal-notifier processes', function(done) {
+      utils.fileCommandJson = function(n, o, cb) {
+        setTimeout(function() {
+          cb(null, '');
+          // After the callback the notification will be cleared.
+          // Calling `clearAll` should be a no-op
+          notifier.clearAll();
+          expect(mockProcess.kill.mock.calls.length).toBe(0);
+          done();
+        }, 0);
+        return mockProcess;
+      };
+      notifier.notify({ message: 'Hello World' }, function() {});
+    });
+  });
 });


### PR DESCRIPTION
I have a use case where I'd like to keep notifier processes running while the application is running, so that they work for the duration of the application. The issue with long timeouts is that they will block the exit of a node program until it reaches the timeout. To fix this I've added a `clearAll` function that will clear the notifier processes. This fixes node programs from being blocked by the terminal processes on exit.

Currently I've only done this for `terminal-notifier`, I can make this change for the other platforms however I don't have a proper way to test them.