### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "9"
+  - "node"
+  - "10"
   - "8"
-  - "7"
   - "6"
+install: npm install


### PR DESCRIPTION
Current LTS are 6, 8 and 10. 11 is current stable. All odd release branches have already reached their EOL. See https://github.com/nodejs/Release/blob/master/README.md