### PR TITLE
Enables the use of WindowsToaster when using WSL

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var os = require('os');
 var utils = require('./lib/utils');
+var isWSL = require('is-wsl');
 
 // All notifiers
 var NotifySend = require('./notifiers/notifysend');
@@ -10,7 +11,9 @@ var WindowsBalloon = require('./notifiers/balloon');
 
 var options = { withFallback: true };
 
-switch (os.type()) {
+var osType = isWSL ? 'WSL' : os.type();
+
+switch (osType) {
   case 'Linux':
     module.exports = new NotifySend(options);
     module.exports.Notification = NotifySend;
@@ -27,6 +30,10 @@ switch (os.type()) {
       module.exports = new WindowsToaster(options);
       module.exports.Notification = WindowsToaster;
     }
+    break;
+  case 'WSL':
+    module.exports = new WindowsToaster(options);
+    module.exports.Notification = WindowsToaster;
     break;
   default:
     if (os.type().match(/BSD$/)) {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var os = require('os');
 var utils = require('./lib/utils');
-var isWSL = require('is-wsl');
 
 // All notifiers
 var NotifySend = require('./notifiers/notifysend');
@@ -11,7 +10,7 @@ var WindowsBalloon = require('./notifiers/balloon');
 
 var options = { withFallback: true };
 
-var osType = isWSL ? 'WSL' : os.type();
+var osType = utils.isWSL() ? 'WSL' : os.type();
 
 switch (osType) {
   case 'Linux':

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 var shellwords = require('shellwords');
 var cp = require('child_process');
 var semver = require('semver');
+var isWSL = require('is-wsl');
 var path = require('path');
 var url = require('url');
 var os = require('os');
@@ -483,6 +484,10 @@ module.exports.isWin8 = function() {
     os.type() === 'Windows_NT' &&
     semver.satisfies(garanteeSemverFormat(os.release()), '>=6.2.9200')
   );
+};
+
+module.exports.isWSL = function() {
+  return isWSL;
 };
 
 module.exports.isLessThanWin8 = function() {

--- a/notifiers/toaster.js
+++ b/notifiers/toaster.js
@@ -79,7 +79,7 @@ WindowsToaster.prototype.notify = function(options, callback) {
     return this;
   }
 
-  if (!utils.isWin8() && !!this.options.withFallback) {
+  if (!utils.isWin8() && !utils.isWSL() && !!this.options.withFallback) {
     fallback = fallback || new Balloon(this.options);
     return fallback.notify(options, callback);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3222,6 +3222,11 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "growly": "^1.3.0",
+    "is-wsl": "^1.1.0",
     "semver": "^5.5.0",
     "shellwords": "^0.1.1",
     "which": "^1.3.0"


### PR DESCRIPTION
This uses the very simple [`is-wsl`](https://github.com/sindresorhus/is-wsl) package to check when node is being run under WSL (Windows Subsystem for Linux) and instead of using Linux's `NotifySend` notifier (which doesn't work) uses `WindowsToaster`.

Without this change, notifications inside WSL don't popup on Windows.