### PR TITLE
Remove Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-notifier [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][depstat-image]][depstat-url]
+# node-notifier [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url]
 
 Send cross platform native notifications using Node.js. Notification Center for macOS,
 `notify-osd`/`libnotify-bin` for Linux, Toasters for Windows 8/10, or taskbar balloons for
@@ -451,5 +451,3 @@ node: {
 [npm-downloads]: http://img.shields.io/npm/dm/node-notifier.svg?style=flat
 [travis-url]: http://travis-ci.org/mikaelbr/node-notifier
 [travis-image]: http://img.shields.io/travis/mikaelbr/node-notifier.svg?style=flat
-[depstat-url]: https://gemnasium.com/mikaelbr/node-notifier
-[depstat-image]: http://img.shields.io/gemnasium/mikaelbr/node-notifier.svg?style=flat


### PR DESCRIPTION
[Gemnasium is no longer available](https://docs.gitlab.com/ee/user/project/import/gemnasium.html). The badge currently only reads “gemnasium: no longer available”.