### PR TITLE
Allow timeout: false to remove a timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,7 @@ notifier.notify(
 **Note:** The `wait` option is shorthand for `timeout: 5`. This just sets a timeout
 for 5 seconds. It does _not_ make the notification sticky!
 
-Without `wait` or `timeout`, notifications are just fired and forgotten. They don't
-wait for any response.
-
-To make notifications wait for a response (like activation/click), you must define
-a `timeout`.
+As of 5.4.0, `timeout` defaults to `10`. In order to have a "fire and forgotten" notification, you need to set `timeout` to `false`.
 
 _Exception:_ If `reply` is defined, it's recommended to set `timeout` to a either
 high value, or to nothing at all.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -211,7 +211,11 @@ module.exports.mapToMac = function(options) {
   }
 
   if (!options.wait && !options.timeout) {
-    options.timeout = 10;
+    if (options.timeout === false) {
+      delete options.timeout;
+    } else {
+      options.timeout = 10;
+    }
   }
 
   options.json = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-notifier",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/terminal-notifier.js
+++ b/test/terminal-notifier.js
@@ -277,6 +277,28 @@ describe('terminal-notifier', function() {
       });
     });
 
+    it('should not set a default timeout if explicitly false', function(done) {
+      var expected = [
+        '-title',
+        '"Title"',
+        '-message',
+        '"Message"',
+        '-json',
+        '"true"'
+      ];
+
+      expectArgsListToBe(expected, done);
+      var notifier = new NotificationCenter();
+      notifier.isNotifyChecked = true;
+      notifier.hasNotifier = true;
+
+      notifier.notify({
+        title: 'Title',
+        message: 'Message',
+        timeout: false
+      });
+    });
+
     it('should escape all title and message', function(done) {
       var expected = [
         '-title',


### PR DESCRIPTION
We ran into a jest issue (https://github.com/facebook/jest/issues/7890) where the new default timeout causes jest to think that the notification isn't finished after 1 second (which it isn't). I couldn't find a way in the current options (as pointed out in 270) to get the old "fire and forget" behavior. 

Related to #218, fix for #270. Allows for `timeout: false` to overwrite the default timeout set to allow for "fire and forgotten" notifications again.

I added a test for this, and all the tests were passing again. Let me know if you have any issues or comments and I can address them :)