### PR TITLE
NotifySend support for app name

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,7 +43,9 @@ var notifySendFlags = {
   category: 'category',
   subtitle: 'category',
   h: 'hint',
-  hint: 'hint'
+  hint: 'hint',
+  a: 'app-name',
+  'app-name': 'app-name'
 };
 
 module.exports.command = function(notifier, options, cb) {

--- a/notifiers/notifysend.js
+++ b/notifiers/notifysend.js
@@ -72,7 +72,7 @@ NotifySend.prototype.notify = function(options, callback) {
   return this;
 };
 
-var allowedArguments = ['urgency', 'expire-time', 'icon', 'category', 'hint'];
+var allowedArguments = ['urgency', 'expire-time', 'icon', 'category', 'hint', 'app-name'];
 
 function doNotification(options, callback) {
   var initial, argsList;


### PR DESCRIPTION
Hello, notify-send has an option to set the app name, but I couldn't be able to pass that option through node-notifier, so I made the additions that enables people to use that option if they want to, using node-notifier.
Although it seems notify-send man page doesn't say anything about this option, it's definitively there, I tested the option under some Ubuntu based systems and notify-send recognizes the option, also you can find information about the option from other sources like this one [notify-send options](http://vaskovsky.net/notify-send/linux.html).
One thing this option does is let you change the "notify-send" default app name, that shows in the notification no matter what in some notifications system.
For example, executing `notifier.notify({title: 'Hello Message', message: 'This is a node-notifier message'})` and we get:
![Screenshot_20191217_040932](https://user-images.githubusercontent.com/25506386/70973078-ae949880-2083-11ea-9d2f-d12cf7e288a6.png)
But after these changes, you can do `notifier.notify({title: 'Hello Message', message: 'This is a node-notifier message', 'app-name': 'node-notifier'})` to get:
![Screenshot_20191217_041029](https://user-images.githubusercontent.com/25506386/70973177-e56aae80-2083-11ea-9086-8ec039a13455.png)

> screenshots taken from KDE plasma, and ubuntu based system
