### PR TITLE
Automagically Bind `notify` Methods

### DIFF
--- a/notifiers/balloon.js
+++ b/notifiers/balloon.js
@@ -50,7 +50,7 @@ function WindowsBalloon(options) {
 util.inherits(WindowsBalloon, EventEmitter);
 
 function noop() {}
-WindowsBalloon.prototype.notify = function(options, callback) {
+function notifyRaw(options, callback) {
   var fallback;
   var notifierOptions = this.options;
   options = utils.clone(options || {});
@@ -105,7 +105,14 @@ WindowsBalloon.prototype.notify = function(options, callback) {
   });
 
   return this;
-};
+}
+
+Object.defineProperty(WindowsBalloon.prototype, 'notify', {
+  get: function() {
+    if (!this._notify) this._notify = notifyRaw.bind(this);
+    return this._notify;
+  }
+});
 
 var allowedArguments = ['t', 'd', 'p', 'm', 'i', 'e', 'q', 'w', 'xp'];
 

--- a/notifiers/growl.js
+++ b/notifiers/growl.js
@@ -28,7 +28,7 @@ function Growl(options) {
 }
 util.inherits(Growl, EventEmitter);
 
-Growl.prototype.notify = function(options, callback) {
+function notifyRaw(options, callback) {
   growly.setHost(this.options.host, this.options.port);
   options = utils.clone(options || {});
 
@@ -71,6 +71,13 @@ Growl.prototype.notify = function(options, callback) {
     callback();
   });
   return this;
-};
+}
+
+Object.defineProperty(Growl.prototype, 'notify', {
+  get: function() {
+    if (!this._notify) this._notify = notifyRaw.bind(this);
+    return this._notify;
+  }
+});
 
 function noop() {}

--- a/notifiers/notificationcenter.js
+++ b/notifiers/notificationcenter.js
@@ -31,7 +31,7 @@ util.inherits(NotificationCenter, EventEmitter);
 var activeId = null;
 
 function noop() {}
-NotificationCenter.prototype.notify = function(options, callback) {
+function notifyRaw(options, callback) {
   var fallbackNotifier;
   var id = identificator();
   options = utils.clone(options || {});
@@ -93,7 +93,14 @@ NotificationCenter.prototype.notify = function(options, callback) {
 
   callback(new Error(errorMessageOsX));
   return this;
-};
+}
+
+Object.defineProperty(NotificationCenter.prototype, 'notify', {
+  get: function() {
+    if (!this._notify) this._notify = notifyRaw.bind(this);
+    return this._notify;
+  }
+});
 
 function identificator() {
   return { _ref: 'val' };

--- a/notifiers/notifysend.js
+++ b/notifiers/notifysend.js
@@ -26,7 +26,7 @@ function NotifySend(options) {
 util.inherits(NotifySend, EventEmitter);
 
 function noop() {}
-NotifySend.prototype.notify = function(options, callback) {
+function notifyRaw(options, callback) {
   options = utils.clone(options || {});
   callback = callback || noop;
 
@@ -70,7 +70,14 @@ NotifySend.prototype.notify = function(options, callback) {
   }
 
   return this;
-};
+}
+
+Object.defineProperty(NotifySend.prototype, 'notify', {
+  get: function() {
+    if (!this._notify) this._notify = notifyRaw.bind(this);
+    return this._notify;
+  }
+});
 
 var allowedArguments = ['urgency', 'expire-time', 'icon', 'category', 'hint'];
 

--- a/notifiers/toaster.js
+++ b/notifiers/toaster.js
@@ -49,7 +49,7 @@ function getPipeName() {
   return `${PIPE_PATH_PREFIX}${PIPE_NAME}-${uuid()}`;
 }
 
-WindowsToaster.prototype.notify = function(options, callback) {
+function notifyRaw(options, callback) {
   options = utils.clone(options || {});
   callback = callback || noop;
   var is64Bit = os.arch() === 'x64';
@@ -142,4 +142,11 @@ WindowsToaster.prototype.notify = function(options, callback) {
     );
   });
   return this;
-};
+}
+
+Object.defineProperty(WindowsToaster.prototype, 'notify', {
+  get: function() {
+    if (!this._notify) this._notify = notifyRaw.bind(this);
+    return this._notify;
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3056,9 +3056,9 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -6460,23 +6460,14 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.3.tgz",
-      "integrity": "sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
+      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.3",
+        "commander": "~2.20.0",
         "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "union-value": {
@@ -6563,9 +6554,10 @@
       }
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3056,9 +3056,9 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -6460,14 +6460,23 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.3.tgz",
+      "integrity": "sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "union-value": {
@@ -6554,10 +6563,9 @@
       }
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",


### PR DESCRIPTION
Automagically bind `notify` methods on all wrapper classes so the notify method can be destructured within the import statement and not run into any `this` related errors.