### PR TITLE
prepend "XDG_RUNTIME_DIR" to command method in order to fix #226

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,7 +54,7 @@ module.exports.command = function(notifier, options, cb) {
     console.info('[notifier options]', options.join(' '));
   }
 
-  return cp.exec(notifier + ' ' + options.join(' '), function(
+  return cp.exec('XDG_RUNTIME_DIR=/run/user/$(id -u) ' + notifier + ' ' + options.join(' '), function(
     error,
     stdout,
     stderr


### PR DESCRIPTION
In #226 some people complained that node-notifier doesnt work if the script is automatically invoked by CRON.
SPDUK however found a soloution which is to prepend
`XDG_RUNTIME_DIR=/run/user/$(id -u) `
to the command, i think we should modify the way `node-notifier` calls the notify-send function so it just works out of the box.

I cant check whether this is working cross platform, on Linux it works like a charm, other platforms have to be tested, i dont have any windows/mac machine here so i unforunately cant test it :/