### PR TITLE
Use new uuidjs import convention

### DIFF
--- a/notifiers/toaster.js
+++ b/notifiers/toaster.js
@@ -6,7 +6,7 @@ var notifier = path.resolve(__dirname, '../vendor/snoreToast/snoretoast');
 var utils = require('../lib/utils');
 var Balloon = require('./balloon');
 var os = require('os');
-const uuid = require('uuid/v4');
+const { v4: uuid } = require('uuid');
 
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');


### PR DESCRIPTION
Deep require of uuid versions is deprecated with v7 and should be replaced with the corresponding import. More details at https://github.com/uuidjs/uuid#deep-requires-now-deprecated