### PR TITLE
fix: fixes mapping on snoretoast activate event, fixes #291

### DIFF
--- a/notifiers/toaster.js
+++ b/notifiers/toaster.js
@@ -109,11 +109,8 @@ function notifyRaw(options, callback) {
   var actionJackedCallback = (err) =>
     snoreToastResultParser(
       err,
-      utils.actionJackerDecorator(
-        this,
-        options,
-        callback,
-        (data) => data || false
+      utils.actionJackerDecorator(this, options, callback, (data) =>
+        data === 'activate' ? 'click' : data || false
       )
     );
 


### PR DESCRIPTION
The mapper-function for the resultantData did not map "activate" to "click", so fixed the mapper to handle this. 

This introduces a breaking change.