### PR TITLE
Add metadata parameter to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ notifier.notify(
     sound: true, // Only Notification Center or Windows Toasters
     wait: true // Wait with callback, until user action is taken against notification, does not apply to Windows Toasters as they always wait or notify-send as it does not support the wait option
   },
-  function (err, response) {
+  function (err, response, metadata) {
     // Response is response from notification
+    // Metadata contains activationType, activationAt, deliveredAt
   }
 );
 


### PR DESCRIPTION
The metadata parameter was missing from the "Cross-Platform Advanced Usage" example in README.md