### PR TITLE
fix: Issue #294 NSAllowsArbitraryLoads flag set to false 

### DIFF
--- a/vendor/mac.noindex/terminal-notifier.app/Contents/Info.plist
+++ b/vendor/mac.noindex/terminal-notifier.app/Contents/Info.plist
@@ -49,7 +49,7 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<false/>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2012-2016 Eloy Durán, Julien Blanchard. All rights reserved.</string>


### PR DESCRIPTION
Based on the [comments of the author](https://github.com/julienXX/terminal-notifier/issues/275#issuecomment-561371857) of terminal-notifier, this flag was initially set to true to allow using icons with http link, however, given the security issues raised by code-analysers, it is a good practice to disable usage of http.