### PR TITLE
detail explanation for electron packaging issues (electron-builder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,18 @@ You can do so with the following command:
 asar pack . app.asar --unpack "./node_modules/node-notifier/vendor/**"
 ```
 
+Or if you use `electron-builder` without using asar directly, append `build` object to your `package.json` as below:
+
+```bash
+...
+build: {
+  asarUnpack: [
+    './node_modules/node-notifier/**/*',
+  ]
+},
+...
+```
+
 ### Using with pkg
 
 For issues using with the pkg module. Check this issue out: https://github.com/mikaelbr/node-notifier/issues/220#issuecomment-425963752


### PR DESCRIPTION
Most users use `electron-builder` to build electron apps, not using asar directly.

I append detail explanation for who use `electron-builder`. This works same like previous command, and is `electron-builder`'s recommended method(https://www.electron.build/configuration/configuration#overridable-per-platform-options).