### PR TITLE
Fix issue #377: Fix customPath option in WindowsToaster constructor

### DIFF
--- a/notifiers/toaster.js
+++ b/notifiers/toaster.js
@@ -133,7 +133,7 @@ function notifyRaw(options, callback) {
     resultBuffer = out;
     options.pipeName = server.namedPipe;
 
-    const localNotifier = options.customPath ||
+    const localNotifier = options.customPath || this.options.customPath ||
       (notifier + '-x' + (is64Bit ? '64' : '86') + '.exe');
 
     options = utils.mapToWin8(options);

--- a/test/toaster.js
+++ b/test/toaster.js
@@ -329,4 +329,47 @@ describe('WindowsToaster', function () {
       actions: ['Ok', 'Cancel'],
     });
   });
+
+  it('should call custom notifier when customPath is passed via message', (done) => {
+    utils.fileCommand = function (notifier, argsList, callback) {
+      expect(notifier).toEqual('/test/customPath/snoretoast-x64.exe');
+      done();
+    };
+
+    const notifier = new Notify();
+
+    notifier.notify({
+      title: 'Heya',
+      message: 'foo bar',
+      extra: 'dsakdsa',
+      foo: 'bar',
+      close: 123,
+      bar: true,
+      id: 1337,
+      sound: 'Notification.IM',
+      customPath: '/test/customPath/snoretoast-x64.exe',
+      actions: ['Ok', 'Cancel'],
+    });
+  });
+
+  it('should call custom notifier when customPath is passed via constructor', (done) => {
+    utils.fileCommand = function (notifier, argsList, callback) {
+      expect(notifier).toEqual('/test/customPath/snoretoast-x64.exe');
+      done();
+    };
+
+    const notifier = new Notify({ customPath: '/test/customPath/snoretoast-x64.exe' });
+
+    notifier.notify({
+      title: 'Heya',
+      message: 'foo bar',
+      extra: 'dsakdsa',
+      foo: 'bar',
+      close: 123,
+      bar: true,
+      id: 1337,
+      sound: 'Notification.IM',
+      actions: ['Ok', 'Cancel'],
+    });
+  });
 });


### PR DESCRIPTION
Fix #377
This PR #373 caused customPath set in WindowsToaster constructor to be ignored.

* Fix use of customPath passed to constructor
* Added 2 unit tests