### PR TITLE
Drop uuid package

### DIFF
--- a/notifiers/toaster.js
+++ b/notifiers/toaster.js
@@ -6,7 +6,7 @@ const notifier = path.resolve(__dirname, '../vendor/snoreToast/snoretoast');
 const utils = require('../lib/utils');
 const Balloon = require('./balloon');
 const os = require('os');
-const { v4: uuid } = require('uuid');
+const { randomUUID: uuid } = require('crypto');
 
 const EventEmitter = require('events').EventEmitter;
 const util = require('util');
@@ -133,8 +133,10 @@ function notifyRaw(options, callback) {
     resultBuffer = out;
     options.pipeName = server.namedPipe;
 
-    const localNotifier = options.customPath || this.options.customPath ||
-      (notifier + '-x' + (is64Bit ? '64' : '86') + '.exe');
+    const localNotifier =
+      options.customPath ||
+      this.options.customPath ||
+      notifier + '-x' + (is64Bit ? '64' : '86') + '.exe';
 
     options = utils.mapToWin8(options);
     const argsList = utils.constructArgumentList(options, {
@@ -144,11 +146,7 @@ function notifyRaw(options, callback) {
       noEscape: true
     });
 
-    utils.fileCommand(
-      localNotifier,
-      argsList,
-      actionJackedCallback
-    );
+    utils.fileCommand(localNotifier, argsList, actionJackedCallback);
   });
   return this;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "is-wsl": "^2.2.0",
         "semver": "^7.3.5",
         "shellwords": "^0.1.1",
-        "uuid": "^8.3.2",
         "which": "^2.0.2"
       },
       "devDependencies": {
@@ -10105,6 +10104,8 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -18285,7 +18286,9 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "optional": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "is-wsl": "^2.2.0",
     "semver": "^7.3.5",
     "shellwords": "^0.1.1",
-    "uuid": "^8.3.2",
     "which": "^2.0.2"
   },
   "lint-staged": {

--- a/test/toaster.js
+++ b/test/toaster.js
@@ -3,8 +3,8 @@ const utils = require('../lib/utils');
 const path = require('path');
 const os = require('os');
 const testUtils = require('./_test-utils');
-jest.mock('uuid', () => {
-  return { v4: () => '123456789' };
+jest.mock('crypto', () => {
+  return { randomUUID: () => '123456789' };
 });
 
 describe('WindowsToaster', function () {
@@ -66,7 +66,7 @@ describe('WindowsToaster', function () {
       icon: 'file:///C:/node-notifier/test/fixture/coulson.jpg',
       id: 1337,
       sound: 'Notification.IM',
-      actions: ['Ok', 'Cancel'],
+      actions: ['Ok', 'Cancel']
     });
   });
 
@@ -80,7 +80,7 @@ describe('WindowsToaster', function () {
     notifier.notify({
       title: 'Heya',
       message: 'foo bar',
-      silent: true,
+      silent: true
     });
   });
 
@@ -93,7 +93,7 @@ describe('WindowsToaster', function () {
 
     notifier.notify({
       title: 'Heya',
-      message: 'foo bar',
+      message: 'foo bar'
     });
   });
 
@@ -106,7 +106,7 @@ describe('WindowsToaster', function () {
 
     notifier.notify({
       message: 'Heya',
-      appIcon: 'file:///C:/node-notifier/test/fixture/coulson.jpg',
+      appIcon: 'file:///C:/node-notifier/test/fixture/coulson.jpg'
     });
   });
 
@@ -249,7 +249,7 @@ describe('WindowsToaster', function () {
     notifier.notify({
       title: 'Heya',
       message: 'foo bar',
-      sound: 'Notification.IM',
+      sound: 'Notification.IM'
     });
   });
 
@@ -264,7 +264,7 @@ describe('WindowsToaster', function () {
     notifier.notify({
       title: 'Heya',
       message: 'foo bar',
-      icon: 'file:///C:/node-notifier/test/fixture/coulson.jpg',
+      icon: 'file:///C:/node-notifier/test/fixture/coulson.jpg'
     });
   });
 
@@ -310,7 +310,7 @@ describe('WindowsToaster', function () {
         '-s',
         'Notification.IM',
         '-b',
-        'Ok;Cancel',
+        'Ok;Cancel'
       ]);
     };
     const notifier = new Notify();
@@ -326,7 +326,7 @@ describe('WindowsToaster', function () {
       icon: 'file:///C:/node-notifier/test/fixture/coulson.jpg',
       id: 1337,
       sound: 'Notification.IM',
-      actions: ['Ok', 'Cancel'],
+      actions: ['Ok', 'Cancel']
     });
   });
 
@@ -348,7 +348,7 @@ describe('WindowsToaster', function () {
       id: 1337,
       sound: 'Notification.IM',
       customPath: '/test/customPath/snoretoast-x64.exe',
-      actions: ['Ok', 'Cancel'],
+      actions: ['Ok', 'Cancel']
     });
   });
 
@@ -358,7 +358,9 @@ describe('WindowsToaster', function () {
       done();
     };
 
-    const notifier = new Notify({ customPath: '/test/customPath/snoretoast-x64.exe' });
+    const notifier = new Notify({
+      customPath: '/test/customPath/snoretoast-x64.exe'
+    });
 
     notifier.notify({
       title: 'Heya',
@@ -369,7 +371,7 @@ describe('WindowsToaster', function () {
       bar: true,
       id: 1337,
       sound: 'Notification.IM',
-      actions: ['Ok', 'Cancel'],
+      actions: ['Ok', 'Cancel']
     });
   });
 });


### PR DESCRIPTION
This PR drops the uuid package from project dependencies and substitutes it with the native [crypto module](https://nodejs.org/docs/latest-v14.x/api/crypto.html) from Node.js.