### PR TITLE
fix: GitHub Actions workflow now tests with different node versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 21.x]
 
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm ci
       - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
         node-version: [14.x, 16.x, 18.x, 20.x, 21.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies


### PR DESCRIPTION
Previously the GitHub Actions workflow would run the same tests (5 tests) with node version 12. 
The GitHub Actions workflow now uses all the node versions specified in ```matrix.node-version```.

Also updated the node-version list to have more recent versions of node and bumped actions used to newer versions.