### PR TITLE
Adding support for actions for notify-send version >=0.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,12 +344,24 @@ See full usage on the [project homepage: **`notifu`**](http://www.paralint.com/p
 
 ### Usage: `NotifySend`
 
-**Note:** `notify-send` doesn't support the `wait` flag.
+**Note:** `notify-send` <0.8.2 doesn't support the `wait` flag.
+
+**Note:** `notify-send` >=0.8.2 supports actions.
 
 ```javascript
 const NotifySend = require('node-notifier').NotifySend;
 
 var notifier = new NotifySend();
+
+notifier.on('ok', () => {
+  console.log('"OK" was pressed');
+});
+notifier.on('cancel', () => {
+  console.log('"Cancel" was pressed');
+});
+notifier.on('activate', () => {
+  console.log('notification was clicked');
+});
 
 notifier.notify({
   title: 'Foo',
@@ -363,11 +375,14 @@ notifier.notify({
   'app-name': 'node-notifier',
   urgency: undefined,
   category: undefined,
-  hint: undefined
+  hint: undefined,
+  actions: ['OK', 'Cancel'] // Name of action in lowercase will be used as event name
 });
 ```
 
 See flags and options on the man page [`notify-send(1)`](http://manpages.ubuntu.com/manpages/gutsy/man1/notify-send.1.html)
+
+Run `example/toaster-with-actions` to see handling of action response.
 
 ## Thanks to OSS
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ See full usage on the [project homepage: **`notifu`**](http://www.paralint.com/p
 
 **Note:** `notify-send` <0.8.2 doesn't support the `wait` flag.
 
-**Note:** `notify-send` >=0.8.2 supports actions.
+**Note:** `notify-send` >=0.8.2 supports `action` and `wait` flags.
 
 ```javascript
 const NotifySend = require('node-notifier').NotifySend;
@@ -376,13 +376,13 @@ notifier.notify({
   urgency: undefined,
   category: undefined,
   hint: undefined,
-  actions: ['OK', 'Cancel'] // Name of action in lowercase will be used as event name
+  actions: ['OK', 'Cancel'] // Name of action in lowercase will be used as event name; implicitly adds '--wait' as well.
 });
 ```
 
 See flags and options on the man page [`notify-send(1)`](http://manpages.ubuntu.com/manpages/gutsy/man1/notify-send.1.html)
 
-Run `example/toaster-with-actions` to see handling of action response.
+Run `example/notify-send.js` to see handling of action response. **You must run this example from a real terminal, it doesn't work from inside e.g. VSCode since libnotify will be in `confined` mode then.**
 
 ## Thanks to OSS
 

--- a/example/notify-send.js
+++ b/example/notify-send.js
@@ -1,0 +1,84 @@
+const notifier = require('../index');
+const path = require('path');
+
+notifier.on('activate', function (notifierObject, options, event) {
+  console.log(
+    'clicked:',
+    JSON.stringify(notifierObject, null, 2),
+    JSON.stringify(options, null, 2),
+    JSON.stringify(event, null, 2)
+  );
+});
+
+notifier.on('timeout', function (notifierObject, options) {
+  // does not work for notify-send
+  console.log(
+    'timeout:',
+    JSON.stringify(notifierObject, null, 2),
+    JSON.stringify(options, null, 2)
+  );
+});
+
+notifier.on('yes', (nn, options, x) => {
+  console.log(
+    'YES',
+    JSON.stringify(options, null, 2),
+    JSON.stringify(x, null, 2)
+  );
+});
+notifier.on('no', (nn, options) => {
+  console.log('NO', JSON.stringify(options, null, 2));
+});
+notifier.on('ok', (nn, options) => {
+  console.log('OK', JSON.stringify(options, null, 2));
+});
+
+const testNotificationWithoutActions = () => {
+  notifier.notify(
+    {
+      title: 'My awesome title',
+      message: 'Hello from node, Mr. User!',
+      icon: path.resolve(path.join(__dirname, 'coulson.jpg')), // Absolute path (doesn't work on balloons)
+      sound: true, // Only Notification Center or Windows Toasters
+      wait: true // Wait with callback, until user action is taken against notification, does not apply to Windows Toasters as they always wait or notify-send as it does not support the wait option
+      // actions: ['OK']
+    },
+    function (err, response, metadata) {
+      // Response (is response from notification
+      // Metadata contains activationType, activationAt, deliveredAt
+      console.log(
+        'cb:',
+        JSON.stringify(err, null, 2),
+        JSON.stringify(response, null, 2),
+        JSON.stringify(metadata, null, 2)
+      );
+    }
+  );
+};
+
+const testNotificationWithActions = () => {
+  notifier.notify(
+    {
+      title: 'My awesome title',
+      message: 'Hello from node, Mr. User!',
+      icon: path.resolve(path.join(__dirname, 'coulson.jpg')), // Absolute path (doesn't work on balloons)
+      sound: true, // Only Notification Center or Windows Toasters
+      actions: ['Yes', 'No']
+    },
+    function (err, response, metadata) {
+      // Response is response from notification
+      // Metadata contains activationType, activationAt, deliveredAt
+      console.log(
+        'cb:',
+        JSON.stringify(err, null, 2),
+        JSON.stringify(response, null, 2),
+        JSON.stringify(metadata, null, 2)
+      );
+    }
+  );
+};
+
+if (require.main === module) {
+  setTimeout(testNotificationWithActions, 10);
+  setTimeout(testNotificationWithoutActions, 10000);
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,7 +45,10 @@ const notifySendFlags = {
   h: 'hint',
   hint: 'hint',
   a: 'app-name',
-  'app-name': 'app-name'
+  'app-name': 'app-name',
+  action: 'action',
+  A: 'action',
+  actions: 'action'
 };
 
 module.exports.command = function (notifier, options, cb) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,7 +48,9 @@ const notifySendFlags = {
   'app-name': 'app-name',
   action: 'action',
   A: 'action',
-  actions: 'action'
+  actions: 'action',
+  w: 'wait',
+  wait: 'wait'
 };
 
 module.exports.command = function (notifier, options, cb) {
@@ -59,14 +61,13 @@ module.exports.command = function (notifier, options, cb) {
     console.info('[notifier options]', options.join(' '));
   }
 
-  return cp.exec(notifier + ' ' + options.join(' '), function (
-    error,
-    stdout,
-    stderr
-  ) {
-    if (error) return cb(error);
-    cb(stderr, stdout);
-  });
+  return cp.exec(
+    notifier + ' ' + options.join(' '),
+    function (error, stdout, stderr) {
+      if (error) return cb(error);
+      cb(stderr, stdout);
+    }
+  );
 };
 
 module.exports.fileCommand = function (notifier, options, cb) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -300,6 +300,7 @@ module.exports.constructArgumentList = function (options, extra) {
   const explicitTrue = !!extra.explicitTrue;
   const keepNewlines = !!extra.keepNewlines;
   const wrapper = extra.wrapper === undefined ? '"' : extra.wrapper;
+  const arrayArgToMultipleArgs = extra.arrayArgToMultipleArgs || false;
 
   const escapeFn = function escapeFn(arg) {
     if (isArray(arg)) {
@@ -326,7 +327,13 @@ module.exports.constructArgumentList = function (options, extra) {
       if (explicitTrue && options[key] === true) {
         args.push('-' + keyExtra + key);
       } else if (explicitTrue && options[key] === false) continue;
-      else args.push('-' + keyExtra + key, escapeFn(options[key]));
+      else {
+        if (arrayArgToMultipleArgs && isArray(options[key])) {
+          for (const val of options[key]) {
+            args.push('-' + keyExtra + key, escapeFn(val));
+          }
+        } else args.push('-' + keyExtra + key, escapeFn(options[key]));
+      }
     }
   }
   return args;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -539,6 +539,8 @@ function garanteeSemverFormat(version) {
   return version;
 }
 
+module.exports.garanteeSemverFormat = garanteeSemverFormat;
+
 function sanitizeNotifuTypeArgument(type) {
   if (typeof type === 'string' || type instanceof String) {
     if (type.toLowerCase() === 'info') return 'info';

--- a/notifiers/notifysend.js
+++ b/notifiers/notifysend.js
@@ -156,12 +156,16 @@ class NotifySend extends EventEmitter {
       'hint',
       'app-name'
     ];
-    if (hasActionsCapability) allowedArguments.push('action');
+    if (hasActionsCapability) {
+      allowedArguments.push('action');
+      allowedArguments.push('wait');
+    }
 
     const argsList = utils.constructArgumentList(options, {
       initial: initial,
       keyExtra: '-',
       arrayArgToMultipleArgs: hasActionsCapability,
+      explicitTrue: true,
       allowedArguments: allowedArguments
     });
 

--- a/notifiers/notifysend.js
+++ b/notifiers/notifysend.js
@@ -73,13 +73,21 @@ function notifyRaw(options, callback) {
 }
 
 Object.defineProperty(NotifySend.prototype, 'notify', {
-  get: function() {
+  get: function () {
     if (!this._notify) this._notify = notifyRaw.bind(this);
     return this._notify;
   }
 });
 
-const allowedArguments = ['urgency', 'expire-time', 'icon', 'category', 'hint', 'app-name'];
+const allowedArguments = [
+  'action',
+  'urgency',
+  'expire-time',
+  'icon',
+  'category',
+  'hint',
+  'app-name'
+];
 
 function doNotification(options, callback) {
   options = utils.mapToNotifySend(options);
@@ -89,9 +97,15 @@ function doNotification(options, callback) {
   delete options.title;
   delete options.message;
 
+  if ('actions' in options) {
+    options.action = options.actions;
+    delete options.actions;
+  }
+
   const argsList = utils.constructArgumentList(options, {
     initial: initial,
     keyExtra: '-',
+    arrayArgToMultipleArgs: true,
     allowedArguments: allowedArguments
   });
 

--- a/notifiers/notifysend.js
+++ b/notifiers/notifysend.js
@@ -6,78 +6,11 @@ const which = require('which');
 const utils = require('../lib/utils');
 
 const EventEmitter = require('events').EventEmitter;
-const util = require('util');
 
 const notifier = 'notify-send';
 let hasNotifier;
 
-module.exports = NotifySend;
-
-function NotifySend(options) {
-  options = utils.clone(options || {});
-  if (!(this instanceof NotifySend)) {
-    return new NotifySend(options);
-  }
-
-  this.options = options;
-
-  EventEmitter.call(this);
-}
-util.inherits(NotifySend, EventEmitter);
-
 function noop() {}
-function notifyRaw(options, callback) {
-  options = utils.clone(options || {});
-  callback = callback || noop;
-
-  if (typeof callback !== 'function') {
-    throw new TypeError(
-      'The second argument must be a function callback. You have passed ' +
-        typeof callback
-    );
-  }
-
-  if (typeof options === 'string') {
-    options = { title: 'node-notifier', message: options };
-  }
-
-  if (!options.message) {
-    callback(new Error('Message is required.'));
-    return this;
-  }
-
-  if (os.type() !== 'Linux' && !os.type().match(/BSD$/)) {
-    callback(new Error('Only supported on Linux and *BSD systems'));
-    return this;
-  }
-
-  if (hasNotifier === false) {
-    callback(new Error('notify-send must be installed on the system.'));
-    return this;
-  }
-
-  if (hasNotifier || !!this.options.suppressOsdCheck) {
-    doNotification(options, callback);
-    return this;
-  }
-
-  try {
-    hasNotifier = !!which.sync(notifier);
-    doNotification(options, callback);
-  } catch (err) {
-    hasNotifier = false;
-    return callback(err);
-  }
-
-  return this;
-}
-
-Object.defineProperty(NotifySend.prototype, 'notify', {
-  get: function () {
-    if (!this._notify) this._notify = notifyRaw.bind(this);
-    return this._notify;
-  }
-});
 
 const NotifySendActionJackerDecorator = function (
   emitter,
@@ -125,42 +58,96 @@ const NotifySendActionJackerDecorator = function (
   };
 };
 
-const allowedArguments = [
-  'action',
-  'urgency',
-  'expire-time',
-  'icon',
-  'category',
-  'hint',
-  'app-name'
-];
-
-function doNotification(options, callback) {
-  options = utils.mapToNotifySend(options);
-  options.title = options.title || 'Node Notification:';
-
-  const initial = [options.title, options.message];
-  delete options.title;
-  delete options.message;
-
-  if ('actions' in options) {
-    options.action = options.actions;
-    delete options.actions;
+class NotifySend extends EventEmitter {
+  constructor(options) {
+    super();
+    this.options = utils.clone(options || {});
   }
 
-  const argsList = utils.constructArgumentList(options, {
-    initial: initial,
-    keyExtra: '-',
-    arrayArgToMultipleArgs: true,
-    allowedArguments: allowedArguments
-  });
+  notify(options, callback) {
+    options = utils.clone(options || {});
+    callback = callback || noop;
+    if (typeof callback !== 'function') {
+      throw new TypeError(
+        'The second argument must be a function callback. You have passed ' +
+          typeof callback
+      );
+    }
 
-  const actionJackedCallback = NotifySendActionJackerDecorator(
-    this,
-    options,
-    callback,
-    null
-  );
+    if (typeof options === 'string') {
+      options = { title: 'node-notifier', message: options };
+    }
 
-  utils.command(notifier, argsList, actionJackedCallback);
+    if (!options.message) {
+      callback(new Error('Message is required.'));
+      return this;
+    }
+
+    if (os.type() !== 'Linux' && !os.type().match(/BSD$/)) {
+      callback(new Error('Only supported on Linux and *BSD systems'));
+      return this;
+    }
+
+    if (hasNotifier === false) {
+      callback(new Error('notify-send must be installed on the system.'));
+      return this;
+    }
+
+    if (hasNotifier || !!this.options.suppressOsdCheck) {
+      this._doNotification(options, callback);
+      return this;
+    }
+
+    try {
+      hasNotifier = !!which.sync(notifier);
+      this._doNotification(options, callback);
+    } catch (err) {
+      hasNotifier = false;
+      return callback(err);
+    }
+
+    return this;
+  }
+
+  _doNotification(options, callback) {
+    options = utils.mapToNotifySend(options);
+    options.title = options.title || 'Node Notification:';
+
+    const initial = [options.title, options.message];
+    delete options.title;
+    delete options.message;
+
+    if ('actions' in options) {
+      options.action = options.actions;
+      delete options.actions;
+    }
+
+    const allowedArguments = [
+      'action',
+      'urgency',
+      'expire-time',
+      'icon',
+      'category',
+      'hint',
+      'app-name'
+    ];
+
+    const argsList = utils.constructArgumentList(options, {
+      initial: initial,
+      keyExtra: '-',
+      arrayArgToMultipleArgs: true,
+      allowedArguments: allowedArguments
+    });
+
+    const actionJackedCallback = NotifySendActionJackerDecorator(
+      this,
+      options,
+      callback,
+      null
+    );
+
+    utils.command(notifier, argsList, actionJackedCallback);
+  }
 }
+
+module.exports = NotifySend;

--- a/notifiers/notifysend.js
+++ b/notifiers/notifysend.js
@@ -136,17 +136,18 @@ class NotifySend extends EventEmitter {
   }
 
   _doNotification(options, callback) {
+    if ('actions' in options) {
+      // rename actions to action
+      options.action = options.actions;
+      delete options.actions;
+    }
+    const originalOptions = utils.clone(options); // nearly original options
     options = utils.mapToNotifySend(options);
     options.title = options.title || 'Node Notification:';
 
     const initial = [options.title, options.message];
     delete options.title;
     delete options.message;
-
-    if ('actions' in options) {
-      options.action = options.actions;
-      delete options.actions;
-    }
 
     const allowedArguments = [
       'urgency',
@@ -175,7 +176,7 @@ class NotifySend extends EventEmitter {
 
     const actionJackedCallback = NotifySendActionJackerDecorator(
       this,
-      options,
+      originalOptions,
       callback,
       null
     );

--- a/notifiers/notifysend.js
+++ b/notifiers/notifysend.js
@@ -111,6 +111,17 @@ const NotifySendActionJackerDecorator = function (
     }
 
     fn.apply(emitter, [err, resultantData, metadata]);
+    if (!resultantData && !err) {
+      emitter.emit('activate', emitter, options, metadata);
+      return;
+    }
+    if (!err) {
+      emitter.emit(resultantData, emitter, options, metadata);
+      return;
+    }
+    if (err) {
+      emitter.emit('error', emitter, options, err);
+    }
   };
 };
 

--- a/notifiers/notifysend.js
+++ b/notifiers/notifysend.js
@@ -148,16 +148,15 @@ class NotifySend extends EventEmitter {
       delete options.actions;
     }
 
-    let allowedArguments = [
+    const allowedArguments = [
       'urgency',
       'expire-time',
       'icon',
       'category',
       'hint',
-      'app-name',
-      'action'
+      'app-name'
     ];
-    if (!hasActionsCapability) allowedArguments.pop();
+    if (hasActionsCapability) allowedArguments.push('action');
 
     const argsList = utils.constructArgumentList(options, {
       initial: initial,
@@ -166,8 +165,9 @@ class NotifySend extends EventEmitter {
       allowedArguments: allowedArguments
     });
 
-    if (!hasActionsCapability)
+    if (!hasActionsCapability) {
       return utils.command(notifier, argsList, callback);
+    }
 
     const actionJackedCallback = NotifySendActionJackerDecorator(
       this,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1854,14 +1854,24 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001634",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001634.tgz",
+      "integrity": "sha512-fbBYXQ9q3+yp1q1gBk86tOFs4pyn/yxFm5ZNP18OXJDfA3txImOY9PhfxVggZ4vRHDqoU8NrKU81eN0OtzOgRA==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -11926,9 +11936,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001634",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001634.tgz",
+      "integrity": "sha512-fbBYXQ9q3+yp1q1gBk86tOFs4pyn/yxFm5ZNP18OXJDfA3txImOY9PhfxVggZ4vRHDqoU8NrKU81eN0OtzOgRA==",
       "dev": true
     },
     "capture-exit": {

--- a/test/notify-send.js
+++ b/test/notify-send.js
@@ -184,4 +184,16 @@ describe('notify-send', function () {
       actions: ['Yes', 'No', 'May`be`']
     });
   });
+
+  it('should keep wait switch (and add expire-time option)', function (done) {
+    const expected = ['"title"', '"body"', '--wait', '--expire-time', '"5000"'];
+
+    expectArgsListToBe(expected, done);
+    const notifier = new Notify({ suppressOsdCheck: true });
+    notifier.notify({
+      title: 'title',
+      message: 'body',
+      wait: true
+    });
+  });
 });

--- a/test/notify-send.js
+++ b/test/notify-send.js
@@ -130,4 +130,58 @@ describe('notify-send', function () {
       tullball: 'notValid'
     });
   });
+
+  it('should add one action option per action entry', function (done) {
+    const expected = [
+      '"title"',
+      '"body"',
+      '--icon',
+      '"icon-string"',
+      '--action',
+      '"Yes"',
+      '--action',
+      '"No"',
+      '--action',
+      '"May\\`be\\`"',
+      '--expire-time',
+      '"10000"'
+    ];
+
+    expectArgsListToBe(expected, done);
+    const notifier = new Notify({ suppressOsdCheck: true });
+    notifier.notify({
+      title: 'title',
+      message: 'body',
+      icon: 'icon-string',
+      tullball: 'notValid',
+      action: ['Yes', 'No', 'May`be`']
+    });
+  });
+
+  it('should add one action option per actionS entry', function (done) {
+    const expected = [
+      '"title"',
+      '"body"',
+      '--icon',
+      '"icon-string"',
+      '--action',
+      '"Yes"',
+      '--action',
+      '"No"',
+      '--action',
+      '"May\\`be\\`"',
+      '--expire-time',
+      '"10000"'
+    ];
+
+    expectArgsListToBe(expected, done);
+    const notifier = new Notify({ suppressOsdCheck: true });
+    notifier.notify({
+      title: 'title',
+      message: 'body',
+      icon: 'icon-string',
+      tullball: 'notValid',
+      actions: ['Yes', 'No', 'May`be`']
+    });
+  });
 });


### PR DESCRIPTION
Ubuntu 23.10 and Ubuntu 24.04 are shipped with notify-send and libnotify versions >=0.8.2, so it supports notification actions.

[https://manpages.ubuntu.com/manpages/mantic/en/man1/notify-send.1.html](https://manpages.ubuntu.com/manpages/mantic/en/man1/notify-send.1.html)

The "--action" option needs to be set multiple times if there are multiple actions. I hacked something together that does that. I also wanted to use events with those actions, but for some reason had to refactor NotifySend into an ES6 class to make it work.

Only tested on Ubuntu 24.04 so far. Hints and comments welcome.
